### PR TITLE
Added CocoaPods support

### DIFF
--- a/Keyboard-Kit.podspec
+++ b/Keyboard-Kit.podspec
@@ -25,7 +25,7 @@ Apps created with AppKit tend to have better support for keyboard control compar
       'KeyboardKit/KeyValueCoding.h'
     ]
     spec.exclude_files = [
-      'KeyboardKit/info.plist',
+      'KeyboardKit/Info.plist',
       'KeyboardKit/UpdateLocalisedStringKeys.swift'
     ]
 

--- a/Keyboard-Kit.podspec
+++ b/Keyboard-Kit.podspec
@@ -1,0 +1,32 @@
+Pod::Spec.new do |spec|
+    spec.name = 'Keyboard-Kit'
+    spec.module_name = 'KeyboardKit'
+    spec.version = '0.0.1'
+    spec.license = { :type => 'MIT', :file => 'License.txt' }
+    spec.homepage = 'https://github.com/douglashill/KeyboardKit'
+    spec.authors = { 'Douglas Hill' => 'https://twitter.com/qdoug' }
+    spec.summary = 'A framework to help iOS and Mac Catalyst apps support being controlled using a hardware keyboard.'
+
+    spec.description = <<-DESC
+KeyboardKit is a framework to help iOS and Mac Catalyst apps support being controlled using a hardware keyboard.
+
+Keyboard control is a standard expectation of Mac apps. It’s important on iOS too because a hardware keyboard improves speed and ergonomics, which makes an iPad an even more powerful productivity machine.
+
+Apps created with AppKit tend to have better support for keyboard control compared to UIKit-based apps. I believe the principal reason for this is that most AppKit components respond to key input out of the box, while most UIKit components do not. KeyboardKit aims to narrow this gap by providing subclasses of UIKit components that respond to key commands.
+                       DESC
+
+    spec.source = { :git => 'https://github.com/douglashill/KeyboardKit.git', :tag => spec.version.to_s }
+    spec.swift_version = '5.0'
+    spec.ios.deployment_target  = '13.0'
+    spec.source_files = 'KeyboardKit/*.{h,m,swift}'
+    spec.public_header_files = [
+      'KeyboardKit/KeyboardKit.h',
+      'KeyboardKit/BarButtonItem.h',
+      'KeyboardKit/KeyValueCoding.h'
+    ]
+    spec.exclude_files = [
+      'KeyboardKit/info.plist',
+      'KeyboardKit/UpdateLocalisedStringKeys.swift'
+    ]
+
+end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ At this early stage the project has only been tested on iOS 13 and Xcode 11.2.1.
 
 KeyboardKit is written in Swift.
 
+## Installation
+
+### CocoaPods
+
+1. Add the following line to your `podfile`:
+
+```swift
+pod 'Keyboard-Kit'
+```
+2. Run the following command in terminal:
+
+```swift
+pod install
+```
+3. Import the framework
+
+```swift
+import KeyboardKit
+```
+
+
 ## Usage
 
 Instead of creating or subclassing a UIKit class directly, use the subclasses from KeyboardKit instead.


### PR DESCRIPTION
## What was done?
- Added `Keyboard-Kit.podspec` so we can support distribution via CocoaPods.

## Notes
- Needed to force iOS 13 for now since we are currently using a lot of iOS 13 APIs. I'm assuming you can play around them with `#if available` but I'll leave the decision and implementation up to you.
- Currently, we can't support Swift Package Manager because of the localisable strings. However, I think providing localisation support is a responsibility this framework shouldn't have (IMO). It makes it harder to scale and maintain since you have to provide everything upfront. For example, instead of this we could provide a **(a)** configuration singleton in which we could inject the strings at launch and/or **(b)** use dependency injection to inject in each element individually (this can be a little annoying but useful in some cases)
