### PR TITLE
Tests and text input

### DIFF
--- a/KeyboardKit.xcodeproj/project.pbxproj
+++ b/KeyboardKit.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		A53EA62F239F1C4D0065C8EB /* KeyValueCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = A53EA62D239F1C4D0065C8EB /* KeyValueCoding.m */; };
 		A542D89C23A01DC8007E68C3 /* PointAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A542D89B23A01DC8007E68C3 /* PointAnimator.swift */; };
 		A54EFB1023AADEB8001776A2 /* TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54EFB0F23AADEB8001776A2 /* TextInput.swift */; };
+		A55D7AF223C1108300302D79 /* KeyboardKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D7AF123C1108300302D79 /* KeyboardKitTests.swift */; };
+		A55D7AF423C1108300302D79 /* KeyboardKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A53AE0052375AAAE00B07957 /* KeyboardKit.framework */; };
 		A56FFD532398718100E13773 /* KeyboardNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56FFD522398718100E13773 /* KeyboardNavigationController.swift */; };
 		A56FFD55239871A800E13773 /* KeyboardBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56FFD54239871A800E13773 /* KeyboardBarButtonItem.swift */; };
 		A56FFD582398776C00E13773 /* BarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A56FFD562398776C00E13773 /* BarButtonItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -48,6 +50,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		A53AE00A2375AAAE00B07957 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A53ADFE12375AA1600B07957 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A53AE0042375AAAE00B07957;
+			remoteInfo = KeyboardKit;
+		};
+		A55D7AF523C1108300302D79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A53ADFE12375AA1600B07957 /* Project object */;
 			proxyType = 1;
@@ -90,6 +99,9 @@
 		A542D89B23A01DC8007E68C3 /* PointAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointAnimator.swift; sourceTree = "<group>"; };
 		A54D2DFA23B7921C0090A11B /* ResponderChainDebugging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ResponderChainDebugging.m; sourceTree = "<group>"; };
 		A54EFB0F23AADEB8001776A2 /* TextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInput.swift; sourceTree = "<group>"; };
+		A55D7AEF23C1108300302D79 /* KeyboardKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeyboardKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A55D7AF123C1108300302D79 /* KeyboardKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardKitTests.swift; sourceTree = "<group>"; };
+		A55D7AF323C1108300302D79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A56FFD522398718100E13773 /* KeyboardNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardNavigationController.swift; sourceTree = "<group>"; };
 		A56FFD54239871A800E13773 /* KeyboardBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardBarButtonItem.swift; sourceTree = "<group>"; };
 		A56FFD562398776C00E13773 /* BarButtonItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BarButtonItem.h; sourceTree = "<group>"; };
@@ -131,6 +143,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A55D7AEC23C1108300302D79 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A55D7AF423C1108300302D79 /* KeyboardKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -140,6 +160,7 @@
 				A5CEF298239837EC0099A19D /* README.md */,
 				A53AE0062375AAAE00B07957 /* KeyboardKit */,
 				A53ADFEB2375AA1600B07957 /* KeyboardKitDemo */,
+				A55D7AF023C1108300302D79 /* KeyboardKitTests */,
 				A53ADFEA2375AA1600B07957 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -149,6 +170,7 @@
 			children = (
 				A53ADFE92375AA1600B07957 /* KeyboardKitDemo.app */,
 				A53AE0052375AAAE00B07957 /* KeyboardKit.framework */,
+				A55D7AEF23C1108300302D79 /* KeyboardKitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -206,6 +228,15 @@
 			path = KeyboardKit;
 			sourceTree = "<group>";
 		};
+		A55D7AF023C1108300302D79 /* KeyboardKitTests */ = {
+			isa = PBXGroup;
+			children = (
+				A55D7AF123C1108300302D79 /* KeyboardKitTests.swift */,
+				A55D7AF323C1108300302D79 /* Info.plist */,
+			);
+			path = KeyboardKitTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -260,6 +291,24 @@
 			productReference = A53AE0052375AAAE00B07957 /* KeyboardKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		A55D7AEE23C1108300302D79 /* KeyboardKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A55D7AF923C1108300302D79 /* Build configuration list for PBXNativeTarget "KeyboardKitTests" */;
+			buildPhases = (
+				A55D7AEB23C1108300302D79 /* Sources */,
+				A55D7AEC23C1108300302D79 /* Frameworks */,
+				A55D7AED23C1108300302D79 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A55D7AF623C1108300302D79 /* PBXTargetDependency */,
+			);
+			name = KeyboardKitTests;
+			productName = KeyboardKitTests;
+			productReference = A55D7AEF23C1108300302D79 /* KeyboardKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -267,7 +316,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = KBD;
-				LastSwiftUpdateCheck = 1110;
+				LastSwiftUpdateCheck = 1130;
 				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = "Douglas Hill";
 				TargetAttributes = {
@@ -277,6 +326,9 @@
 					A53AE0042375AAAE00B07957 = {
 						CreatedOnToolsVersion = 11.1;
 						LastSwiftMigration = 1120;
+					};
+					A55D7AEE23C1108300302D79 = {
+						CreatedOnToolsVersion = 11.3;
 					};
 				};
 			};
@@ -295,6 +347,7 @@
 			targets = (
 				A53AE0042375AAAE00B07957 /* KeyboardKit */,
 				A53ADFE82375AA1600B07957 /* KeyboardKitDemo */,
+				A55D7AEE23C1108300302D79 /* KeyboardKitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -314,6 +367,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5E5389F239B0387004A2EE2 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A55D7AED23C1108300302D79 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,6 +447,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A55D7AEB23C1108300302D79 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A55D7AF223C1108300302D79 /* KeyboardKitTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -394,6 +462,11 @@
 			isa = PBXTargetDependency;
 			target = A53AE0042375AAAE00B07957 /* KeyboardKit */;
 			targetProxy = A53AE00A2375AAAE00B07957 /* PBXContainerItemProxy */;
+		};
+		A55D7AF623C1108300302D79 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A53AE0042375AAAE00B07957 /* KeyboardKit */;
+			targetProxy = A55D7AF523C1108300302D79 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -628,6 +701,44 @@
 			};
 			name = Release;
 		};
+		A55D7AF723C1108300302D79 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3A8QT46Z78;
+				INFOPLIST_FILE = KeyboardKitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.douglashill.KeyboardKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A55D7AF823C1108300302D79 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3A8QT46Z78;
+				INFOPLIST_FILE = KeyboardKitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.douglashill.KeyboardKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -654,6 +765,15 @@
 			buildConfigurations = (
 				A53AE00F2375AAAE00B07957 /* Debug */,
 				A53AE0102375AAAE00B07957 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A55D7AF923C1108300302D79 /* Build configuration list for PBXNativeTarget "KeyboardKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A55D7AF723C1108300302D79 /* Debug */,
+				A55D7AF823C1108300302D79 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/KeyboardKit.xcodeproj/xcshareddata/xcschemes/KeyboardKitDemo.xcscheme
+++ b/KeyboardKit.xcodeproj/xcshareddata/xcschemes/KeyboardKitDemo.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:KeyboardKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A55D7AEE23C1108300302D79"
+               BuildableName = "KeyboardKitTests.xctest"
+               BlueprintName = "KeyboardKitTests"
+               ReferencedContainer = "container:KeyboardKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A55D7AEE23C1108300302D79"
+               BuildableName = "KeyboardKitTests.xctest"
+               BlueprintName = "KeyboardKitTests"
+               ReferencedContainer = "container:KeyboardKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/KeyboardKit/KeyInputStrings.swift
+++ b/KeyboardKit/KeyInputStrings.swift
@@ -7,6 +7,7 @@ extension String {
     static let delete = "\u{8}" // This is the backspace ASCII control character, which is known as the delete key on Apple platforms.
     static let `return` = "\r"
     static let space = " "
+    static let tab = "\t"
     static let escape = UIKeyCommand.inputEscape
 
     static let upArrow = UIKeyCommand.inputUpArrow

--- a/KeyboardKit/KeyboardNavigationController.swift
+++ b/KeyboardKit/KeyboardNavigationController.swift
@@ -52,7 +52,7 @@ open class KeyboardNavigationController: UINavigationController {
             additionalCommands += topViewController.nnToolbarItems.compactMap(keyCommandFromBarButtonItem)
 
             if UIResponder.isTextInputActive {
-                additionalCommands = additionalCommands.filter { $0.isAllowedWhileTextInputIsActive }
+                additionalCommands = additionalCommands.filter { $0.doesConflictWithTextInput == false }
             }
 
             commands += additionalCommands

--- a/KeyboardKit/TextInput.swift
+++ b/KeyboardKit/TextInput.swift
@@ -68,14 +68,14 @@ extension UIKeyCommand {
         case .pageUp, .pageDown, .home, .end:
             // These are never used for text input.
             return false
-        case "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "c", "g", "l", "q", "r", "s", "u", "v", "w", "x", "y", "z", "-", "[", "]", "\\", ";", "'", "=", "`", ",", ".", "/":
-            // These don’t do anything with the control key.
-            let notUsedForTextInput = modifierFlags.contains(.command) || modifierFlags.contains(.control)
+        case "a", "b", "d", "e", "f", "h", "i", "j", "k", "m", "n", "o", "p", "t":
+            // http://www.hcs.harvard.edu/~jrus/Site/system-bindings.html minus some that don’t work on iOS, plus some that do something on iOS but not on Mac.
+            // These do something useful in text input with control or shift + control. Command or control + option are not used for text input.
+            let notUsedForTextInput = modifierFlags.contains(.command) || modifierFlags.contains(.control) && modifierFlags.contains(.alternate)
             return notUsedForTextInput == false
         default:
-            // Command or control + option are not used for text input (except for the cases above).
-            // Everything else is for text input.
-            let notUsedForTextInput = modifierFlags.contains(.command) || modifierFlags.contains(.control) && modifierFlags.contains(.alternate)
+            // These don’t do anything with the control key.
+            let notUsedForTextInput = modifierFlags.contains(.command) || modifierFlags.contains(.control)
             return notUsedForTextInput == false
         }
     }

--- a/KeyboardKit/TextInput.swift
+++ b/KeyboardKit/TextInput.swift
@@ -68,6 +68,11 @@ extension UIKeyCommand {
         case .pageUp, .pageDown, .home, .end:
             // These are never used for text input.
             return false
+        default:
+            break
+        }
+        // Normalise case because the system ignores the case. Can’t do this at the start because lowercasing strings like UIKeyInputUpArrow makes them not match.
+        switch (input.lowercased()) {
         case "a", "b", "d", "e", "f", "h", "i", "j", "k", "m", "n", "o", "p", "t":
             // http://www.hcs.harvard.edu/~jrus/Site/system-bindings.html minus some that don’t work on iOS, plus some that do something on iOS but not on Mac.
             // These do something useful in text input with control or shift + control. Command or control + option are not used for text input.

--- a/KeyboardKit/TextInput.swift
+++ b/KeyboardKit/TextInput.swift
@@ -33,28 +33,29 @@ extension UIResponder {
 
 extension UIKeyCommand {
 
-    /// Whether the key command should be allowed to be active while text input is taking place. This is false if the key command would override text input.
+    /// Whether the key command would conflict with text input if text input is active. If this is false the key command can
+    /// safely be active while text input is taking place.
     ///
     /// `UIKeyCommands` from further along the responder chain take priority over the first responder being used for text input.
     /// Overriding keys used for text input is a bad user experience and can easily lead to data loss.
-    var isAllowedWhileTextInputIsActive: Bool {
+    var doesConflictWithTextInput: Bool {
         guard let input = input else {
             // No input means no conflicts. But no way to press the key either.
-            return true
+            return false
         }
 
         // These inputs are used for text input with command so can’t be allowed. The thing with 8 is delete.
         enum __ { static let inputsThatConflict: Set<String> = [.delete, .upArrow, .downArrow, .leftArrow, .rightArrow] }
         if __.inputsThatConflict.contains(input) {
-            return false
+            return true
         }
 
         // Command is not used for text input (except for the cases above). Other modifiers are used for text input. Yes, even control.
         if modifierFlags.contains(.command) {
-            return true
+            return false
         }
 
         // Assume everything else is for text input. Might have forgotten something.
-        return false
+        return true
     }
 }

--- a/KeyboardKitTests/Info.plist
+++ b/KeyboardKitTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/KeyboardKitTests/KeyboardKitTests.swift
+++ b/KeyboardKitTests/KeyboardKitTests.swift
@@ -3,9 +3,309 @@
 @testable import KeyboardKit
 import XCTest
 
+private extension UIKeyCommand {
+    convenience init(_ modifierFlags: UIKeyModifierFlags = [], _ input: String) {
+        self.init((modifierFlags, input), action: #selector(NSObject.accessibilityActivate))
+    }
+}
+
 class KeyboardKitTests: XCTestCase {
 
-    func testExample() {
+    func testTextInputConflicts() {
 
+        // Letters, numbers, punctuation and symbols. These are the same (or close enough) for all input strings.
+
+        XCTAssertTrue(UIKeyCommand([], "a").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.shift, "a").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.alternate, "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.command, "a").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .command], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .command], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], "a").doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], "a").doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], "a").doesConflictWithTextInput)
+
+        // Control and shift control with letters, numbers, punctuation and symbols. These differ with the input string.
+
+        // Technically these do all insert the number so conflict, but they don’t seem useful.
+        XCTAssertFalse(UIKeyCommand(.control, "1").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "1").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "2").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "2").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "3").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "3").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "4").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "4").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "5").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "5").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "6").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "6").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "7").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "7").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "8").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "8").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "9").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "9").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "0").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "0").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], "a").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .command], "7").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], "7").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.control, "a").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "a").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "b").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "b").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "c").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "c").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "d").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "d").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "e").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "e").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "f").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "f").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "g").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "g").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "h").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "h").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "i").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "i").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "j").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "j").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "k").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "k").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "l").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "l").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "m").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "m").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "n").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "n").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "o").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "o").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "p").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "p").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "q").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "q").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "r").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "r").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "s").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "s").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, "t").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "t").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "u").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "u").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "v").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "v").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "w").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "w").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "x").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "x").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "y").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "y").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "z").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "z").doesConflictWithTextInput)
+
+        // These type a backtick (`) for some reason.
+        XCTAssertTrue(UIKeyCommand(.control, "§").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "§").doesConflictWithTextInput)
+
+        // These all type nothing.
+        XCTAssertFalse(UIKeyCommand(.control, "-").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "-").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "[").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "[").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "]").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "]").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "\\").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "\\").doesConflictWithTextInput)
+
+        // These act the same as if shift was the only modifier, so technically these conflict but they don’t seem useful.
+        XCTAssertFalse(UIKeyCommand(.control, ";").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], ";").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "'").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "'").doesConflictWithTextInput)
+
+        // These act the same as if no modifiers were pressed, so technically these conflict but they don’t seem useful.
+        XCTAssertFalse(UIKeyCommand(.control, "=").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "=").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "`").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "`").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, ",").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], ",").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, ".").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], ".").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, "/").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "/").doesConflictWithTextInput)
+
+        // Delete
+
+        XCTAssertTrue(UIKeyCommand([], .delete).doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.shift, .delete).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, .delete).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.alternate, .delete).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.command, .delete).doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand([.shift, .control], .delete).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], .delete).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .command], .delete).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .delete).doesConflictWithTextInput) // Does something but duplicate.
+        XCTAssertFalse(UIKeyCommand([.control, .command], .delete).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .delete).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .delete).doesConflictWithTextInput) // Does something but duplicate.
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .delete).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .delete).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .delete).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .delete).doesConflictWithTextInput)
+
+        // Return
+
+        XCTAssertTrue(UIKeyCommand([], .return).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand(.shift, .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand(.control, .return).doesConflictWithTextInput) // Types a newline. Not useful. Differs from the Mac where this types a paragraph break.
+        XCTAssertFalse(UIKeyCommand(.alternate, .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand(.command, .return).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control], .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate], .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .command], .return).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand([.control, .command], .return).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .return).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .return).doesConflictWithTextInput) // Types a newline. Not useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .return).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .return).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .return).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .return).doesConflictWithTextInput)
+
+        // Arrow keys
+
+        XCTAssertTrue(UIKeyCommand([], .leftArrow).doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.shift, .leftArrow).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.control, .leftArrow).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.alternate, .leftArrow).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.command, .leftArrow).doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand([.shift, .control], .leftArrow).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], .leftArrow).doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .command], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .command], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .leftArrow).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .leftArrow).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .leftArrow).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .leftArrow).doesConflictWithTextInput)
+
+        // Page Down
+
+        XCTAssertFalse(UIKeyCommand([], .pageDown).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand(.shift, .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.alternate, .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.command, .pageDown).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .command], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .command], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .pageDown).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .pageDown).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .pageDown).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .pageDown).doesConflictWithTextInput)
+
+        // Space
+
+        XCTAssertTrue(UIKeyCommand([], .space).doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.shift, .space).doesConflictWithTextInput) // Same as space with no modifiers. Could be useful if holding shift to type in all caps.
+        XCTAssertFalse(UIKeyCommand(.control, .space).doesConflictWithTextInput) // System reserved.
+        XCTAssertTrue(UIKeyCommand(.alternate, .space).doesConflictWithTextInput) // Non-breaking space.
+        XCTAssertFalse(UIKeyCommand(.command, .space).doesConflictWithTextInput) // System reserved.
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control], .space).doesConflictWithTextInput) // System reserved.
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], .space).doesConflictWithTextInput) // Same as option space (non-breaking space). Don’t allow this to be overridden (as with shift space).
+        XCTAssertFalse(UIKeyCommand([.shift, .command], .space).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .space).doesConflictWithTextInput) // Same as space with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.control, .command], .space).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .space).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .space).doesConflictWithTextInput) // Same as space with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .space).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .space).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .space).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .space).doesConflictWithTextInput)
+
+        // Tab
+
+        XCTAssertTrue(UIKeyCommand([], .tab).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand(.shift, .tab).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.control, .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand(.alternate, .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand(.command, .tab).doesConflictWithTextInput) // System reserved.
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control], .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate], .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .command], .tab).doesConflictWithTextInput) // System reserved.
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.control, .command], .tab).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .tab).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .tab).doesConflictWithTextInput) // Same as tab with no modifiers, so technically this conflicts. Not considered useful.
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .tab).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .tab).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .tab).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .tab).doesConflictWithTextInput) // System reserved.
+
+        // Escape
+
+        XCTAssertTrue(UIKeyCommand([], .escape).doesConflictWithTextInput) // Cancels auto-correction suggestion.
+
+        XCTAssertFalse(UIKeyCommand(.shift, .escape).doesConflictWithTextInput) // Same as escape with no modifiers. Not considered useful.
+        XCTAssertFalse(UIKeyCommand(.control, .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.alternate, .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.command, .escape).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .command], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .command], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], .escape).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], .escape).doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], .escape).doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], .escape).doesConflictWithTextInput)
     }
 }

--- a/KeyboardKitTests/KeyboardKitTests.swift
+++ b/KeyboardKitTests/KeyboardKitTests.swift
@@ -1,0 +1,11 @@
+// Douglas Hill, January 2020
+
+@testable import KeyboardKit
+import XCTest
+
+class KeyboardKitTests: XCTestCase {
+
+    func testExample() {
+
+    }
+}

--- a/KeyboardKitTests/KeyboardKitTests.swift
+++ b/KeyboardKitTests/KeyboardKitTests.swift
@@ -115,9 +115,9 @@ class KeyboardKitTests: XCTestCase {
         XCTAssertFalse(UIKeyCommand(.control, "z").doesConflictWithTextInput)
         XCTAssertFalse(UIKeyCommand([.shift, .control], "z").doesConflictWithTextInput)
 
-        // These type a backtick (`) for some reason.
-        XCTAssertTrue(UIKeyCommand(.control, "§").doesConflictWithTextInput)
-        XCTAssertTrue(UIKeyCommand([.shift, .control], "§").doesConflictWithTextInput)
+        // These type a backtick (`) for some reason so technically do conflict but this doesn’t seem useful.
+        XCTAssertFalse(UIKeyCommand(.control, "§").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control], "§").doesConflictWithTextInput)
 
         // These all type nothing.
         XCTAssertFalse(UIKeyCommand(.control, "-").doesConflictWithTextInput)

--- a/KeyboardKitTests/KeyboardKitTests.swift
+++ b/KeyboardKitTests/KeyboardKitTests.swift
@@ -34,6 +34,27 @@ class KeyboardKitTests: XCTestCase {
 
         XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], "a").doesConflictWithTextInput)
 
+        // Same but with a capital A as the input. The system ignore the case.
+
+        XCTAssertTrue(UIKeyCommand([], "A").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand(.shift, "A").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand(.alternate, "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand(.command, "A").doesConflictWithTextInput)
+
+        XCTAssertTrue(UIKeyCommand([.shift, .alternate], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .command], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .command], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.alternate, .command], "A").doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .command], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.shift, .alternate, .command], "A").doesConflictWithTextInput)
+        XCTAssertFalse(UIKeyCommand([.control, .alternate, .command], "A").doesConflictWithTextInput)
+
+        XCTAssertFalse(UIKeyCommand([.shift, .control, .alternate, .command], "A").doesConflictWithTextInput)
+
         // Control and shift control with letters, numbers, punctuation and symbols. These differ with the input string.
 
         // Technically these do all insert the number so conflict, but they don’t seem useful.
@@ -62,6 +83,8 @@ class KeyboardKitTests: XCTestCase {
         XCTAssertFalse(UIKeyCommand([.shift, .command], "7").doesConflictWithTextInput)
         XCTAssertFalse(UIKeyCommand([.control, .alternate], "7").doesConflictWithTextInput)
 
+        XCTAssertTrue(UIKeyCommand(.control, "A").doesConflictWithTextInput)
+        XCTAssertTrue(UIKeyCommand([.shift, .control], "A").doesConflictWithTextInput)
         XCTAssertTrue(UIKeyCommand(.control, "a").doesConflictWithTextInput)
         XCTAssertTrue(UIKeyCommand([.shift, .control], "a").doesConflictWithTextInput)
         XCTAssertTrue(UIKeyCommand(.control, "b").doesConflictWithTextInput)


### PR DESCRIPTION
This branch improves the detection of which key commands conflict with text input. Mostly it now allows more key combinations that don’t do anything with text input.This branch also adds a tests target for the framework which can be run with cmd + U with the demo app scheme. The text input conflicts implementation is now checked by a tediously long test.