### PR TITLE
Sets wantsPriorityOverSystemBehavior to true

### DIFF
--- a/KeyboardKit/SelectableCollectionKeyHandler.swift
+++ b/KeyboardKit/SelectableCollectionKeyHandler.swift
@@ -66,10 +66,14 @@ class SelectableCollectionKeyHandler: InjectableResponder {
         super.init(owner: owner)
     }
 
-    private lazy var selectionKeyCommands: [UIKeyCommand] = [.upArrow, .downArrow, .leftArrow, .rightArrow].flatMap { input -> [UIKeyCommand] in
+    private lazy var selectionKeyCommands: [UIKeyCommand] = [String.upArrow, .downArrow, .leftArrow, .rightArrow].flatMap { input -> [UIKeyCommand] in
         // TODO: Add .shift and [.alternate, .shift] here to support extending multiple selection.
-        [UIKeyModifierFlags(), .alternate].map { modifierFlags in
-            UIKeyCommand((modifierFlags, input), action: #selector(updateSelectionFromKeyCommand))
+        [UIKeyModifierFlags(), .alternate].map { modifierFlags -> UIKeyCommand in
+            let keyCommand = UIKeyCommand((modifierFlags, input), action: #selector(updateSelectionFromKeyCommand))
+            if #available(iOS 15.0, *), modifierFlags.isEmpty {
+                keyCommand.wantsPriorityOverSystemBehavior = true
+            }
+            return keyCommand
         }
     } + [
         UIKeyCommand(.space, action: #selector(activateSelection)),


### PR DESCRIPTION
This PR. fixes selection with arrow keys on iOS/iPadOS 15.

When compiled against the iOS 15 SDK, key commands that use arrow inputs with no modifier keys no longer works. The system will catch those events and not let the app process them using UIKeyCommand. Setting them new [wantsPriorityOverSystemBehavior](https://developer.apple.com/documentation/uikit/uikeycommand/3780513-wantspriorityoversystembehavior) property on UIKeyCommand to true will let the app take priority over system behaviour.

The compiler was acting up when I changed the implicit return to an explicit return, a consequence of storing the UIKeyCommand in a variable. To address the I explicitly told the type checker that the arrow containing the inputs (upArrow, downArrow, ...) is a string array.