### PR TITLE
Avoid crash in cellVisibility(atIndexPath:)

### DIFF
--- a/KeyboardKit/KeyboardCollectionView.swift
+++ b/KeyboardKit/KeyboardCollectionView.swift
@@ -224,8 +224,10 @@ extension UICollectionView: SelectableCollection {
 
         // TODO: The use of frame likely gives incorrect results if there are transforms.
 
-        // Note the force unwrapping. Not sure why this is nullable.
-        let layoutAttributes = collectionViewLayout.layoutAttributesForItem(at: indexPath)!
+        guard let layoutAttributes = collectionViewLayout.layoutAttributesForItem(at: indexPath) else {
+            return .fullyVisible
+        }
+	
         if bounds.inset(by: adjustedContentInset).contains(layoutAttributes.frame) {
             return .fullyVisible
         }


### PR DESCRIPTION
*Motivation:*
<img width="1018" alt="KeyboardKit Crash" src="https://user-images.githubusercontent.com/2340723/135076252-a0b0a0be-2508-4451-a424-c52583798cf3.png">

Sorry I don't have an exact reproducible, but I think it has to do with the collection view being hidden when added to view hierarchy.
Perhaps the 'more correct' fix is making the whole function optional but I think that's overkill - this fixes the issue and when the collection is visible it behaves as expected. 