### PR TITLE
Add extensions for SwiftUI's `KeyboardShortcut`

### DIFF
--- a/KeyboardKit.xcodeproj/project.pbxproj
+++ b/KeyboardKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9646A54828B2664700A10272 /* KeyboardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646A54728B2664700A10272 /* KeyboardAction.swift */; };
 		A521CE5424D61B5C00EBB34D /* CompositionalLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A521CE5324D61B5C00EBB34D /* CompositionalLayoutViewController.swift */; };
 		A53ADFEF2375AA1600B07957 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53ADFEE2375AA1600B07957 /* SceneDelegate.swift */; };
 		A53ADFF62375AA1700B07957 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A53ADFF52375AA1700B07957 /* Assets.xcassets */; };
@@ -146,6 +147,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9646A54728B2664700A10272 /* KeyboardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardAction.swift; sourceTree = "<group>"; };
 		A521CE5324D61B5C00EBB34D /* CompositionalLayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionalLayoutViewController.swift; sourceTree = "<group>"; };
 		A53ADFE92375AA1600B07957 /* KeyboardKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeyboardKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A53ADFEE2375AA1600B07957 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				A57633BE259A62490063269A /* KeyboardDatePicker.swift */,
 				A5D8C55D23A4ED0F00733DD4 /* InjectableResponder.swift */,
 				A542D89B23A01DC8007E68C3 /* PointAnimator.swift */,
+				9646A54728B2664700A10272 /* KeyboardAction.swift */,
 				A554A9882700681E005A066F /* DiscoverableKeyCommand.swift */,
 				A53AE01223786CD000B07957 /* KeyCommandCreation.swift */,
 				A5A1667C23B0461E00E5C3FD /* KeyInputStrings.swift */,
@@ -895,6 +898,7 @@
 				A5D8C55E23A4ED0F00733DD4 /* InjectableResponder.swift in Sources */,
 				A5E538AA239BF644004A2EE2 /* KeyboardTextView.swift in Sources */,
 				A5D20F44237E9AE90057A8EE /* KeyboardScrollView.swift in Sources */,
+				9646A54828B2664700A10272 /* KeyboardAction.swift in Sources */,
 				A53AE01A23786CD000B07957 /* KeyboardCollectionView.swift in Sources */,
 				A554A9892700681E005A066F /* DiscoverableKeyCommand.swift in Sources */,
 				A5D2DD0426EC9AA4000C5D18 /* Documentation.docc in Sources */,

--- a/KeyboardKit/KeyboardAction.swift
+++ b/KeyboardKit/KeyboardAction.swift
@@ -1,0 +1,136 @@
+public enum KeyboardAction {
+    /// An action to cancelling an in-progress task or dismiss a prompt, consisting of the Escape (⎋) key and no modifiers.
+    case cancel
+    
+    /// A close action, consisting of the Escape (⎋) key and no modifiers.
+    case close
+    
+    /// A done action, consisting of the Return (↩) key and the Command (⌘) modifier.
+    case done
+    
+    /// A save action, consisting of the 'S' key and the Command (⌘) modifier.
+    case save
+    
+    case generic
+    
+    /// An edit action, consisting of the 'E' key and the Command (⌘) modifier.
+    case edit
+    
+    /// A creation action, consisting of the 'N' key and the Command (⌘) modifier.
+    case new
+    
+    /// A reply action, consisting of the 'R' key and the Command (⌘) modifier.
+    case reply
+    
+    /// A refresh action, consisting of the 'R' key and the Command (⌘) modifier.
+    case refresh
+    
+    /// An action for viewing bookmarks, consisting of the 'B' key and the Command (⌘) modifier.
+    case bookmarks
+    
+    /// A search action, consisting of the 'F' key and the Command (⌘) modifier.
+    case search
+    
+    /// A deletion action, consisting of the Delete (⌫) key and the Command (⌘) modifier.
+    case delete
+    
+    /// An action for viewing content relating to the current day, consisting of the 'T' key and the Command (⌘) modifier.
+    case today
+    
+    /// A zoom-in action, consisting of the equals (=) key and the Command (⌘) modifier.
+    case zoomIn
+    
+    /// A zoom-out action, consisting of the minus (-) key and the Command (⌘) modifier.
+    case zoomOut
+    
+    /// An action to zoom content to its actual size, consisting of the 0 key and the Command (⌘) modifier.
+    case zoomToActualSize
+    
+    /// A rewind action, consisting of the left arrow (←) key and the Command (⌘) modifier.
+    case rewind
+    
+    /// A fast-forward action, consisting of the right arrow (→) key and the Command (⌘) modifier.
+    case fastForward
+}
+
+// MARK: - Key Equivalent
+
+extension KeyboardAction {
+    var keyEquivalent: (modifierFlags: UIKeyModifierFlags, input: String) {
+        switch self {
+        case .cancel:           return ([], .escape)
+        case .close:            return (.command, "w")
+        // Apparently "\u{3}" might work for enter (not return) but not quite. Shows up in the HUD with no key and I couldn’t get it to trigger. For now use cmd + return instead.
+        // Sources: https://forums.developer.apple.com/thread/119584 and https://stackoverflow.com/questions/56963348/uikeycommand-for-the-enter-key-on-mac-keyboards-numeric-keypad.
+        case .done:             return (.command, .returnOrEnter)
+        case .save:             return (.command, "s")
+        case .generic:          return (.command, "i") // Safari uses this for Email This Page. Also indirectly recommended in https://developer.apple.com/wwdc20/10117.
+        case .edit:             return (.command, "e")
+        case .new:              return (.command, "n")
+        case .reply:            return (.command, "r")
+        case .refresh:          return (.command, "r")
+        case .bookmarks:        return (.command, "b") // opt + cmd + B or shift + cmd + B might be better to be more like Safari.
+        case .search:           return (.command, "f")
+        case .delete:           return (.command, .delete)
+        case .today:            return (.command, "t")
+        case .zoomIn:           return (.command, "=")
+        case .zoomOut:          return (.command, "-")
+        case .zoomToActualSize: return (.command, "0")
+        case .rewind:           return (.command, .leftArrow)
+        case .fastForward:      return (.command, .rightArrow)
+        }
+    }
+}
+
+// MARK: - KeyboardShortcut
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+@available(iOS 14.0, *)
+public extension KeyboardAction {
+    var keyboardShortcut: KeyboardShortcut {
+        let equivalent = keyEquivalent
+        let keyEquivalent = KeyEquivalent(Character(equivalent.input))
+        let modifiers = equivalent.modifierFlags.eventModifiers
+        
+        switch self {
+        case .cancel:
+            return .cancelAction
+        case .rewind, .fastForward:
+            if #available(iOS 15.0, *) {
+                return .init(keyEquivalent, modifiers: modifiers, localization: .withoutMirroring)
+            }
+            
+            fallthrough
+        default:
+            return .init(keyEquivalent, modifiers: modifiers)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+private extension UIKeyModifierFlags {
+    var eventModifiers: EventModifiers {
+        var eventModifiers: EventModifiers = []
+        
+        if self.contains(.command) {
+            eventModifiers.insert(.command)
+        }
+        if self.contains(.numericPad) {
+            eventModifiers.insert(.numericPad)
+        }
+        if self.contains(.shift) {
+            eventModifiers.insert(.shift)
+        }
+        if self.contains(.control) {
+            eventModifiers.insert(.control)
+        }
+        if self.contains(.alphaShift) {
+            eventModifiers.insert(.capsLock)
+        }
+        
+        return eventModifiers
+    }
+}
+#endif

--- a/KeyboardKit/KeyboardBarButtonItem.swift
+++ b/KeyboardKit/KeyboardBarButtonItem.swift
@@ -67,7 +67,7 @@ open class KeyboardBarButtonItem: _KBDBarButtonItem {
 
     /// For KeyboardKit internal use.
     public override func wasInitialised(with systemItem: SystemItem) {
-        keyEquivalent = systemItem.keyEquivalent
+        keyEquivalent = systemItem.keyboardAction?.keyEquivalent
         self.systemItem = systemItem
         keyCommandAllowsAutomaticMirroring = systemItem.allowsAutomaticMirroring
     }
@@ -92,25 +92,23 @@ open class KeyboardBarButtonItem: _KBDBarButtonItem {
 }
 
 private extension UIBarButtonItem.SystemItem {
-    var keyEquivalent: (modifierFlags: UIKeyModifierFlags, input: String)? {
+    var keyboardAction: KeyboardAction? {
         switch self {
-        case .cancel:      return ([], .escape)
-        case .close:       return (.command, "w")
-        // Apparently "\u{3}" might work for enter (not return) but not quite. Shows up in the HUD with no key and I couldn’t get it to trigger. For now use cmd + return instead.
-        // Sources: https://forums.developer.apple.com/thread/119584 and https://stackoverflow.com/questions/56963348/uikeycommand-for-the-enter-key-on-mac-keyboards-numeric-keypad.
-        case .done:        return (.command, .returnOrEnter)
-        case .save:        return (.command, "s")
-        case .action:      return (.command, "i") // Safari uses this for Email This Page. Also indirectly recommended in https://developer.apple.com/wwdc20/10117.
-        case .edit:        return (.command, "e")
-        case .add:         return (.command, "n")
-        case .compose:     return (.command, "n")
-        case .reply:       return (.command, "r")
-        case .refresh:     return (.command, "r")
-        case .bookmarks:   return (.command, "b") // opt + cmd + B or shift + cmd + B might be better to be more like Safari.
-        case .search:      return (.command, "f")
-        case .trash:       return (.command, .delete)
-        case .rewind:      return (.command, .leftArrow)
-        case .fastForward: return (.command, .rightArrow)
+        case .cancel:      return .cancel
+        case .close:       return .close
+        case .done:        return .done
+        case .save:        return .save
+        case .action:      return .generic
+        case .edit:        return .edit
+        case .add:         return .new
+        case .compose:     return .new
+        case .reply:       return .reply
+        case .refresh:     return .refresh
+        case .bookmarks:   return .bookmarks
+        case .search:      return .search
+        case .trash:       return .delete
+        case .rewind:      return .rewind
+        case .fastForward: return .fastForward
         // More obscure items that are hard to pick a standard key equivalent for.
         case .organize:    return nil
         case .camera:      return nil

--- a/KeyboardKit/ScrollViewKeyHandler.swift
+++ b/KeyboardKit/ScrollViewKeyHandler.swift
@@ -54,9 +54,9 @@ class ScrollViewKeyHandler: InjectableResponder, UIScrollViewDelegate {
 
     private lazy var nonDiscoverableZoomingCommands: [UIKeyCommand] = [
         // This is the one users are expected to press. We don’t want to show = in the UI.
-        UIKeyCommand((.command, "="), action: #selector(kbd_zoomIn)),
+        UIKeyCommand(KeyboardAction.zoomIn.keyEquivalent, action: #selector(kbd_zoomIn)),
         // This is the one users are expected to press. This is a hyphen.
-        UIKeyCommand((.command, "-"), action: #selector(kbd_zoomOut)),
+        UIKeyCommand(KeyboardAction.zoomOut.keyEquivalent, action: #selector(kbd_zoomOut)),
         // You can hold shift and press the =/+ key and it still zooms in, so match that for zooming out with the -/_ key.
         UIKeyCommand((.command, "_"), action: #selector(kbd_zoomOut)),
     ]
@@ -67,9 +67,9 @@ class ScrollViewKeyHandler: InjectableResponder, UIScrollViewDelegate {
     // This is a minus sign, not a hyphen, to align nicely in the UI.
     static let zoomOutKeyCommand = DiscoverableKeyCommand((.command, "−"), action: #selector(kbd_zoomOut), title: localisedString(.scrollView_zoomOut))
 
-    static let actualSizeKeyCommand = DiscoverableKeyCommand((.command, "0"), action: #selector(kbd_resetZoom), title: localisedString(.scrollView_zoomReset))
+    static let actualSizeKeyCommand = DiscoverableKeyCommand(KeyboardAction.zoomToActualSize.keyEquivalent, action: #selector(kbd_resetZoom), title: localisedString(.scrollView_zoomReset))
 
-    static let refreshKeyCommand = DiscoverableKeyCommand((.command, "r"), action: #selector(kbd_refresh), title: localisedString(.refresh))
+    static let refreshKeyCommand = DiscoverableKeyCommand(KeyboardAction.refresh.keyEquivalent, action: #selector(kbd_refresh), title: localisedString(.refresh))
 
     override var keyCommands: [UIKeyCommand]? {
         var commands = super.keyCommands ?? []


### PR DESCRIPTION
Add extensions on SwiftUI's [`KeyboardShortcut`](https://developer.apple.com/documentation/swiftui/keyboardshortcut) with common keyboard shortcuts, based on those already defined [as part of `KeyboardBarButtonItem`](https://github.com/douglashill/KeyboardKit/blob/main/KeyboardKit/KeyboardBarButtonItem.swift#L98-L113) and elsewhere elsewhere in KeyboardKit.

It seems difficult to provide much utility for SwiftUI compared to what exists for UIKit at the moment, but I thought this might be useful at the very least.

For some background, SwiftUI has `.keyboardShortcut` view modifier out-of-the-box that takes either a `KeyboardShortcut` or a `KeyEquivalent` (key without modifier), but this modifier can only be applied to a `Button` or `Toggle` to perform their existing action. `KeyboardShortcut` only has two existing defined cases for `cancelAction` (escape) and `defaultAction` (enter).