### PR TITLE
KeyboardMapView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # KeyboardKit change log
 
+- Next
+    - Adds `KeyboardMapView` to let users scroll, zoom and rotate maps using a keyboard.
 - 8.0.0
     - Increases the deployment target from iOS 12 to iOS 13.
         - The following deprecated UIKit APIs are no longer respected: `isModalInPopover`, `popoverPresentationControllerShouldDismissPopover(_:)`, `popoverPresentationControllerDidDismissPopover(_:)`.

--- a/Features.md
+++ b/Features.md
@@ -71,6 +71,18 @@ Scrolling and zooming commands provide feature parity with `NSScrollView` from A
 | Zoom out                                      | ⌘−                          | `KeyboardScrollView`                                                                                                                                       |                                                                                                                                                                                                    |
 | Zoom to actual size                           | ⌘0                          | `KeyboardScrollView`                                                                                                                                       |                                                                                                                                                                                                    |
 
+### Map view
+
+`MKMapView` has had built-in support for scrolling, zooming and rotating the map using a keyboard since iOS 15. However this functionality is unavailable unless you subclass `MKMapView` and override `canBecomeFirstResponder` and `canBecomeFocused` to return true. `KeyboardMapView` unlocks this functionality and adds two other useful commands.
+
+| Feature                       | Key input    | Notes                                             |
+| ----------------------------- | ------------ | ------------------------------------------------- |
+| Scroll map                    | arrow        | Unlocked from `MKMapView`.                        |
+| Zoom map                      | +, -, ⌥↑, ⌥↓ | Unlocked from `MKMapView`.                        |
+| Rotate map (change heading)   | ⌥←, ⌥→       | Unlocked from `MKMapView`.                        |
+| Snap to north (reset heading) | ⇧⌘↑          | Available if `isRotateEnabled` is true.           |
+| Go to current location        | ⌘L           | Available if `showsUserLocation` is true.         |
+
 ## Key equivalents for buttons (SwiftUI and UIKit)
 
 SwiftUI provides the `.keyboardShortcut` modifier to trigger the action of a `Button` from a keyboard. KeyboardKit extends this by providing semantically defined `KeyboardShortcut`s for common actions, which can be used with this modifier.

--- a/KeyboardKit.xcodeproj/project.pbxproj
+++ b/KeyboardKit.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		A542D89C23A01DC8007E68C3 /* PointAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A542D89B23A01DC8007E68C3 /* PointAnimator.swift */; };
 		A54EFB1023AADEB8001776A2 /* TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54EFB0F23AADEB8001776A2 /* TextInput.swift */; };
 		A554A9892700681E005A066F /* DiscoverableKeyCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A554A9882700681E005A066F /* DiscoverableKeyCommand.swift */; };
+		A55B8C09242564D2001E125A /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55B8C08242564D2001E125A /* MapViewController.swift */; };
+		A55B8C0B24256914001E125A /* KeyboardMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55B8C0A24256914001E125A /* KeyboardMapView.swift */; };
 		A55D0B70244B1EFC00492BE7 /* KeyboardScrollingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D0B6F244B1EFC00492BE7 /* KeyboardScrollingDelegate.swift */; };
 		A55D7AF223C1108300302D79 /* KeyboardKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D7AF123C1108300302D79 /* KeyboardKitTests.swift */; };
 		A55D7AF423C1108300302D79 /* KeyboardKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A53AE0052375AAAE00B07957 /* KeyboardKit.framework */; };
@@ -177,6 +179,8 @@
 		A54D2DFA23B7921C0090A11B /* ResponderChainDebugging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ResponderChainDebugging.m; path = ObjC/ResponderChainDebugging.m; sourceTree = "<group>"; };
 		A54EFB0F23AADEB8001776A2 /* TextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInput.swift; sourceTree = "<group>"; };
 		A554A9882700681E005A066F /* DiscoverableKeyCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverableKeyCommand.swift; sourceTree = "<group>"; };
+		A55B8C08242564D2001E125A /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
+		A55B8C0A24256914001E125A /* KeyboardMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMapView.swift; sourceTree = "<group>"; };
 		A55D0B6F244B1EFC00492BE7 /* KeyboardScrollingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollingDelegate.swift; sourceTree = "<group>"; };
 		A55D3C03257AC57B00E5FE07 /* Features.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Features.md; sourceTree = "<group>"; };
 		A55D7AEF23C1108300302D79 /* KeyboardKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeyboardKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -428,6 +432,7 @@
 				A56A4D64250E34A500A55939 /* TripleColumnListViewController.swift */,
 				A55F22B8271B3BD500AFA55E /* MenuBuilder.swift */,
 				A582B00726F719F200E32E25 /* Settings.bundle */,
+				A55B8C08242564D2001E125A /* MapViewController.swift */,
 				A53ADFF52375AA1700B07957 /* Assets.xcassets */,
 				A53ADFF72375AA1700B07957 /* LaunchScreen.storyboard */,
 				A53ADFFA2375AA1700B07957 /* Info.plist */,
@@ -447,6 +452,7 @@
 				A55D0B6F244B1EFC00492BE7 /* KeyboardScrollingDelegate.swift */,
 				A5D8C55923A44BBC00733DD4 /* ScrollViewKeyHandler.swift */,
 				A5E538A9239BF644004A2EE2 /* KeyboardTextView.swift */,
+				A55B8C0A24256914001E125A /* KeyboardMapView.swift */,
 				A53AE01323786CD000B07957 /* KeyboardTabBarController.swift */,
 				A5E3D37E24C4A768008C1FDB /* KeyboardSplitViewController.swift */,
 				A56FFD522398718100E13773 /* KeyboardNavigationController.swift */,
@@ -876,6 +882,7 @@
 				A55F8E86271C15B8001CC20E /* AppDelegate.swift in Sources */,
 				A53AE02023786CDC00B07957 /* TableViewController.swift in Sources */,
 				A590F5A2259A5C8F00781E5E /* DatePickerViewController.swift in Sources */,
+				A55B8C09242564D2001E125A /* MapViewController.swift in Sources */,
 				A53ADFEF2375AA1600B07957 /* SceneDelegate.swift in Sources */,
 				A5E3D37B24C39041008C1FDB /* SidebarViewController.swift in Sources */,
 				A5CEF29723982F9F0099A19D /* PagingScrollViewController.swift in Sources */,
@@ -890,6 +897,7 @@
 				A56FFD55239871A800E13773 /* KeyboardBarButtonItem.swift in Sources */,
 				A57633BF259A62490063269A /* KeyboardDatePicker.swift in Sources */,
 				A56FFD592398776C00E13773 /* BarButtonItem.m in Sources */,
+				A55B8C0B24256914001E125A /* KeyboardMapView.swift in Sources */,
 				A5880D0323A5A24200A6E4DF /* SelectableCollectionKeyHandler.swift in Sources */,
 				A5D2DD4126F0819F000C5D18 /* ResponderChainDebugging.m in Sources */,
 				A5D8C55A23A44BBC00733DD4 /* ScrollViewKeyHandler.swift in Sources */,

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -26,7 +26,7 @@ open class KeyboardMapView: MKMapView {
     /// Input: ⇧⌘↑
     ///
     /// Recommended location in main menu: View
-    public static let resetHeadingKeyCommand = DiscoverableKeyCommand(([.shift, .command], .upArrow), action: #selector(kbd_resetHeading), title: "Snap to North")
+    public static let resetHeadingKeyCommand = DiscoverableKeyCommand(([.shift, .command], .upArrow), action: #selector(kbd_resetHeading), title: localisedString(.map_resetHeading))
 
     /// A key command that shows the user’s current location on a map.
     ///
@@ -37,7 +37,7 @@ open class KeyboardMapView: MKMapView {
     /// Input: ⌘L
     ///
     /// Recommended location in main menu: View
-    public static let goToUserLocationKeyCommand = DiscoverableKeyCommand((.command, "l"), action: #selector(kbd_goToUserLocation), title: "Go to Current Location")
+    public static let goToUserLocationKeyCommand = DiscoverableKeyCommand((.command, "l"), action: #selector(kbd_goToUserLocation), title: localisedString(.map_goToUserLocation))
 
     open override var keyCommands: [UIKeyCommand]? {
         var commands = super.keyCommands ?? []

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -1,0 +1,7 @@
+// Douglas Hill, March 2020
+
+import MapKit
+
+/// A map view that supports hardware keyboard commands to scroll and zoom.
+open class KeyboardMapView: MKMapView {
+}

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -24,11 +24,24 @@ open class KeyboardMapView: MKMapView {
     /// Recommended location in main menu: View
     public static let resetHeadingKeyCommand = DiscoverableKeyCommand(([.shift, .command], .upArrow), action: #selector(kbd_resetHeading), title: "Snap to North")
 
+    /// A key command that shows the user’s current location on a map.
+    ///
+    /// Title: Go to Current Location
+    ///
+    /// Input: ⌘L
+    ///
+    /// Recommended location in main menu: View
+    public static let goToUserLocationKeyCommand = DiscoverableKeyCommand((.command, "l"), action: #selector(kbd_goToUserLocation), title: "Go to Current Location")
+
     open override var keyCommands: [UIKeyCommand]? {
         var commands = super.keyCommands ?? []
 
         if Self.resetHeadingKeyCommand.shouldBeIncludedInResponderChainKeyCommands && canResetHeading {
             commands.append(Self.resetHeadingKeyCommand)
+        }
+
+        if Self.goToUserLocationKeyCommand.shouldBeIncludedInResponderChainKeyCommands && canGoToUserLocation {
+            commands.append(Self.goToUserLocationKeyCommand)
         }
 
         return commands
@@ -38,6 +51,8 @@ open class KeyboardMapView: MKMapView {
         switch action {
         case #selector(kbd_resetHeading):
             return canResetHeading
+        case #selector(kbd_goToUserLocation):
+            return canGoToUserLocation
         default:
             return super.canPerformAction(action, withSender: sender)
         }
@@ -50,6 +65,20 @@ open class KeyboardMapView: MKMapView {
     @objc private func kbd_resetHeading(_ sender: UIKeyCommand) {
         animateCamera {
             $0.heading = 0
+        }
+    }
+
+    private var canGoToUserLocation: Bool {
+        showsUserLocation && userLocation.location != nil
+    }
+
+    @objc func kbd_goToUserLocation(_ sender: UIKeyCommand) {
+        guard let target = userLocation.location else {
+            return
+        }
+
+        animateCamera {
+            $0.centerCoordinate = target.coordinate
         }
     }
 

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -14,4 +14,24 @@ open class KeyboardMapView: MKMapView {
     open override var canBecomeFocused: Bool {
         true
     }
+
+    open override var keyCommands: [UIKeyCommand]? {
+        var commands = super.keyCommands ?? []
+
+        return commands
+    }
+
+    open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        switch action {
+        default:
+            return super.canPerformAction(action, withSender: sender)
+        }
+    }
+
+    /// Animates a modification to the camera specified by the given closure.
+    private func animateCamera(withAdjustment adjustment: (MKMapCamera) -> Void) {
+        let camera = self.camera.copy() as! MKMapCamera
+        adjustment(camera)
+        setCamera(camera, animated: true)
+    }
 }

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -4,7 +4,9 @@ import MapKit
 
 /// A map view that supports hardware keyboard commands to scroll and zoom.
 ///
-/// This relies on system support that was added in iOS 15.
+/// This relies on system support that was added in iOS 15 to scroll the map (arrow keys), zoom in and out (+/- or opt up/down), and rotate (opt left/right).
+///
+/// This subclass adds key commands to reset the rotation (heading) so north if at the top and to show the user’s current location.
 open class KeyboardMapView: MKMapView {
 
     open override var canBecomeFirstResponder: Bool {
@@ -17,6 +19,8 @@ open class KeyboardMapView: MKMapView {
 
     /// A key command that sets the heading of a map so north is at the top.
     ///
+    /// Available if `isRotateEnabled` is true.
+    ///
     /// Title: Snap to North
     ///
     /// Input: ⇧⌘↑
@@ -25,6 +29,8 @@ open class KeyboardMapView: MKMapView {
     public static let resetHeadingKeyCommand = DiscoverableKeyCommand(([.shift, .command], .upArrow), action: #selector(kbd_resetHeading), title: "Snap to North")
 
     /// A key command that shows the user’s current location on a map.
+    ///
+    /// Available if `showsUserLocation` is true.
     ///
     /// Title: Go to Current Location
     ///

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -3,5 +3,15 @@
 import MapKit
 
 /// A map view that supports hardware keyboard commands to scroll and zoom.
+///
+/// This relies on system support that was added in iOS 15.
 open class KeyboardMapView: MKMapView {
+
+    open override var canBecomeFirstResponder: Bool {
+        true
+    }
+
+    open override var canBecomeFocused: Bool {
+        true
+    }
 }

--- a/KeyboardKit/KeyboardMapView.swift
+++ b/KeyboardKit/KeyboardMapView.swift
@@ -15,16 +15,41 @@ open class KeyboardMapView: MKMapView {
         true
     }
 
+    /// A key command that sets the heading of a map so north is at the top.
+    ///
+    /// Title: Snap to North
+    ///
+    /// Input: ⇧⌘↑
+    ///
+    /// Recommended location in main menu: View
+    public static let resetHeadingKeyCommand = DiscoverableKeyCommand(([.shift, .command], .upArrow), action: #selector(kbd_resetHeading), title: "Snap to North")
+
     open override var keyCommands: [UIKeyCommand]? {
         var commands = super.keyCommands ?? []
+
+        if Self.resetHeadingKeyCommand.shouldBeIncludedInResponderChainKeyCommands && canResetHeading {
+            commands.append(Self.resetHeadingKeyCommand)
+        }
 
         return commands
     }
 
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         switch action {
+        case #selector(kbd_resetHeading):
+            return canResetHeading
         default:
             return super.canPerformAction(action, withSender: sender)
+        }
+    }
+
+    private var canResetHeading: Bool {
+        isRotateEnabled
+    }
+
+    @objc private func kbd_resetHeading(_ sender: UIKeyCommand) {
+        animateCamera {
+            $0.heading = 0
         }
     }
 

--- a/KeyboardKit/Localised/ar.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ar.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "بحث عن التالي";
 "find_previous" = "بحث عن السابق";
 "find_useSelection" = "استخدام التحديد للبحث";
+"map_goToUserLocation" = "انتقال إلى الموقع الحالي";
+"map_resetHeading" = "انطباق إلى الشمال";
 "navigation_back" = "رجوع";
 "refresh" = "تحديث";
 "scrollView_zoomIn" = "تكبير";

--- a/KeyboardKit/Localised/ca.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ca.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Buscar el següent";
 "find_previous" = "Buscar l’anterior";
 "find_useSelection" = "Utilitzar la selecció per buscar";
+"map_goToUserLocation" = "Anar a la ubicació actual";
+"map_resetHeading" = "Ajustar al nord";
 "navigation_back" = "Enrere";
 "refresh" = "Actualitzar";
 "scrollView_zoomIn" = "Apropar";

--- a/KeyboardKit/Localised/cs.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/cs.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Hledat další";
 "find_previous" = "Hledat předchozí";
 "find_useSelection" = "Hledat výběr";
+"map_goToUserLocation" = "Přejít na aktuální polohu";
+"map_resetHeading" = "Orientovat na sever";
 "navigation_back" = "Zpět";
 "refresh" = "Obnovit"; // Possible alternative: Aktualizovat
 "scrollView_zoomIn" = "Zvětšit";

--- a/KeyboardKit/Localised/da.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/da.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Find næste";
 "find_previous" = "Find forrige";
 "find_useSelection" = "Søg med det valgte";
+"map_goToUserLocation" = "Gå til aktuel lokalitet";
+"map_resetHeading" = "Ret ind mod nord";
 "navigation_back" = "Tilbage";
 "refresh" = "Opdater";
 "scrollView_zoomIn" = "Zoom ind";

--- a/KeyboardKit/Localised/de.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/de.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Weitersuchen (vorwärts)";
 "find_previous" = "Weitersuchen (rückwärts)";
 "find_useSelection" = "Auswahl für Suche übernehmen";
+"map_goToUserLocation" = "Zum aktuellen Ort";
+"map_resetHeading" = "Nordausrichtung";
 "navigation_back" = "Zurück";
 "refresh" = "Aktualisieren";
 "scrollView_zoomIn" = "Vergrößern";

--- a/KeyboardKit/Localised/el.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/el.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Εύρεση επόμενου";
 "find_previous" = "Εύρεση προηγούμενου";
 "find_useSelection" = "Χρήση επιλογής για εύρεση";
+"map_goToUserLocation" = "Μετάβαση στην τρέχουσα τοποθεσία";
+"map_resetHeading" = "Συγκράτηση στον Βορρά";
 "navigation_back" = "Πίσω";
 "refresh" = "Ανανέωση";
 "scrollView_zoomIn" = "Μεγέθυνση";

--- a/KeyboardKit/Localised/en-AU.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/en-AU.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Find Next";
 "find_previous" = "Find Previous";
 "find_useSelection" = "Use Selection for Find";
+"map_goToUserLocation" = "Go to Current Location";
+"map_resetHeading" = "Snap to North";
 "navigation_back" = "Back";
 "refresh" = "Refresh";
 "scrollView_zoomIn" = "Zoom In";

--- a/KeyboardKit/Localised/en-GB.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/en-GB.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Find Next";
 "find_previous" = "Find Previous";
 "find_useSelection" = "Use Selection for Find";
+"map_goToUserLocation" = "Go to Current Location";
+"map_resetHeading" = "Snap to North";
 "navigation_back" = "Back";
 "refresh" = "Refresh";
 "scrollView_zoomIn" = "Zoom In";

--- a/KeyboardKit/Localised/en.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/en.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Find Next";
 "find_previous" = "Find Previous";
 "find_useSelection" = "Use Selection for Find";
+"map_goToUserLocation" = "Go to Current Location";
+"map_resetHeading" = "Snap to North";
 "navigation_back" = "Back";
 "refresh" = "Refresh";
 "scrollView_zoomIn" = "Zoom In";

--- a/KeyboardKit/Localised/es-419.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/es-419.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Buscar siguiente";
 "find_previous" = "Buscar anterior";
 "find_useSelection" = "Usar selección para buscar";
+"map_goToUserLocation" = "Ir a la ubicación actual";
+"map_resetHeading" = "Ajustar al norte";
 "navigation_back" = "Atrás";
 "refresh" = "Actualizar";
 "scrollView_zoomIn" = "Acercar";

--- a/KeyboardKit/Localised/es.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/es.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Buscar siguiente";
 "find_previous" = "Buscar anterior";
 "find_useSelection" = "Usar selección para buscar";
+"map_goToUserLocation" = "Ir a la ubicación actual";
+"map_resetHeading" = "Ajustar al norte";
 "navigation_back" = "Atrás";
 "refresh" = "Actualizar";
 "scrollView_zoomIn" = "Ampliar";

--- a/KeyboardKit/Localised/fi.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/fi.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Etsi seuraava";
 "find_previous" = "Etsi edellinen";
 "find_useSelection" = "Käytä valintaa etsinnässä";
+"map_goToUserLocation" = "Siirry nykyiseen sijaintiin";
+"map_resetHeading" = "Kohdista pohjoiseen";
 "navigation_back" = "Edellinen"; // Matches navigation controller button text. More common in Apple strings files: Takaisin
 "refresh" = "Päivitä";
 "scrollView_zoomIn" = "Lähennä";

--- a/KeyboardKit/Localised/fr-CA.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/fr-CA.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Rechercher le suivant";
 "find_previous" = "Rechercher le précédent";
 "find_useSelection" = "Rechercher la sélection";
+"map_goToUserLocation" = "Se rendre à la position actuelle";
+"map_resetHeading" = "Orienter vers le nord";
 "navigation_back" = "Retour";
 "refresh" = "Actualiser";
 "scrollView_zoomIn" = "Zoom avant";

--- a/KeyboardKit/Localised/fr.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/fr.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Rechercher le suivant";
 "find_previous" = "Rechercher le précédent";
 "find_useSelection" = "Rechercher la sélection";
+"map_goToUserLocation" = "Aller au lieu actuel";
+"map_resetHeading" = "Orienter vers le nord";
 "navigation_back" = "Retour";
 "refresh" = "Actualiser";
 "scrollView_zoomIn" = "Zoom avant";

--- a/KeyboardKit/Localised/he.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/he.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "חפש את הבא";
 "find_previous" = "חפש את הקודם";
 "find_useSelection" = "השתמש במלל הנבחר לחיפוש";
+"map_goToUserLocation" = "עבור למיקום הנוכחי";
+"map_resetHeading" = "הצמד לצפון";
 "navigation_back" = "הקודם";
 "refresh" = "רענן";
 "scrollView_zoomIn" = "הגדל";

--- a/KeyboardKit/Localised/hi.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/hi.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "अगला ढूँढें";
 "find_previous" = "पिछला ढूँढें";
 "find_useSelection" = "ढूँढने के लिए चयन का उपयोग करें";
+"map_goToUserLocation" = "वर्तमान स्थान पर जाएँ";
+"map_resetHeading" = "उत्तर की ओर स्नैप करें";
 "navigation_back" = "वापस";
 "refresh" = "रीफ़्रेश करें";
 "scrollView_zoomIn" = "ज़ूम इन करें";

--- a/KeyboardKit/Localised/hr.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/hr.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Pronađi sljedeće";
 "find_previous" = "Pronađi prethodno";
 "find_useSelection" = "Koristi odabir za pretraživanje";
+"map_goToUserLocation" = "Idi na trenutačnu lokaciju";
+"map_resetHeading" = "Podesi na sjever";
 "navigation_back" = "Natrag";
 "refresh" = "Osvježi";
 "scrollView_zoomIn" = "Uvećaj";

--- a/KeyboardKit/Localised/hu.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/hu.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Következő keresése";
 "find_previous" = "Előző keresése";
 "find_useSelection" = "A kijelölés használata kereséshez"; // This matches TextEdit. More common in Apple strings files: Kijelölés használata a kereséshez
+"map_goToUserLocation" = "Ugrás a jelenlegi helyzetre";
+"map_resetHeading" = "Illesztés északhoz";
 "navigation_back" = "Vissza";
 "refresh" = "Frissítés";
 "scrollView_zoomIn" = "Nagyítás";

--- a/KeyboardKit/Localised/id.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/id.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Temukan Berikutnya";
 "find_previous" = "Temukan Sebelumnya";
 "find_useSelection" = "Gunakan Pilihan untuk Temukan";
+"map_goToUserLocation" = "Ke Lokasi Saat Ini";
+"map_resetHeading" = "Posisikan ke Utara";
 "navigation_back" = "Kembali";
 "refresh" = "Segarkan";
 "scrollView_zoomIn" = "Perbesar";

--- a/KeyboardKit/Localised/it.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/it.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Cerca successivo";
 "find_previous" = "Cerca precedente";
 "find_useSelection" = "Usa selezione per cercare";
+"map_goToUserLocation" = "Vai alla posizione attuale";
+"map_resetHeading" = "Allinea verso nord";
 "navigation_back" = "Indietro";
 "refresh" = "Aggiorna";
 "scrollView_zoomIn" = "Ingrandisci";

--- a/KeyboardKit/Localised/ja.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ja.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "次を検索";
 "find_previous" = "前を検索";
 "find_useSelection" = "選択部分を検索に使用";
+"map_goToUserLocation" = "現在地に移動";
+"map_resetHeading" = "北を上にする";
 "navigation_back" = "戻る";
 "refresh" = "更新";
 "scrollView_zoomIn" = "拡大";

--- a/KeyboardKit/Localised/ko.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ko.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "다음 찾기";
 "find_previous" = "이전 찾기";
 "find_useSelection" = "선택 부분으로 찾기";
+"map_goToUserLocation" = "현재 위치로 이동";
+"map_resetHeading" = "북쪽으로 방향 잡기";
 "navigation_back" = "뒤로";
 "refresh" = "새로 고침";
 "scrollView_zoomIn" = "확대";

--- a/KeyboardKit/Localised/ms.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ms.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Cari Seterusnya";
 "find_previous" = "Cari Sebelumnya";
 "find_useSelection" = "Guna Pilihan untuk Mencari";
+"map_goToUserLocation" = "Pergi ke Lokasi Semasa";
+"map_resetHeading" = "Lekat ke Utara";
 "navigation_back" = "Balik";
 "refresh" = "Segar Semula";
 "scrollView_zoomIn" = "Zum Masuk";

--- a/KeyboardKit/Localised/nb.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/nb.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Finn neste";
 "find_previous" = "Finn forrige";
 "find_useSelection" = "Bruk markering til søk";
+"map_goToUserLocation" = "Gå til nåværende posisjon";
+"map_resetHeading" = "Orienter mot nord";
 "navigation_back" = "Tilbake";
 "refresh" = "Oppdater";
 "scrollView_zoomIn" = "Zoom inn";

--- a/KeyboardKit/Localised/nl.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/nl.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Zoek volgende";
 "find_previous" = "Zoek vorige";
 "find_useSelection" = "Gebruik selectie voor zoekactie";
+"map_goToUserLocation" = "Ga naar huidige locatie";
+"map_resetHeading" = "Spring naar noorden";
 "navigation_back" = "Vorige";
 "refresh" = "Vernieuw";
 "scrollView_zoomIn" = "Zoom in";

--- a/KeyboardKit/Localised/pl.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/pl.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Znajdź następne";
 "find_previous" = "Znajdź poprzednie";
 "find_useSelection" = "Szukaj zaznaczonego tekstu";
+"map_goToUserLocation" = "Przejdź do bieżącego położenia";
+"map_resetHeading" = "Przyciągaj do północy";
 "navigation_back" = "Wróć";
 "refresh" = "Odśwież";
 "scrollView_zoomIn" = "Powiększ";

--- a/KeyboardKit/Localised/pt-BR.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/pt-BR.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Buscar Seguinte";
 "find_previous" = "Buscar Anterior";
 "find_useSelection" = "Usar Seleção para Buscar";
+"map_goToUserLocation" = "Ir para Localização Atual";
+"map_resetHeading" = "Alinhar ao Norte";
 "navigation_back" = "Voltar";
 "refresh" = "Atualizar";
 "scrollView_zoomIn" = "Ampliar";

--- a/KeyboardKit/Localised/pt-PT.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/pt-PT.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Procurar seguinte";
 "find_previous" = "Procurar anterior";
 "find_useSelection" = "Procurar seleção";
+"map_goToUserLocation" = "Ir para localização atual";
+"map_resetHeading" = "Orientar a Norte";
 "navigation_back" = "Anterior";
 "refresh" = "Atualizar";
 "scrollView_zoomIn" = "Ampliar";

--- a/KeyboardKit/Localised/ro.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ro.lproj/KeyboardKit.strings
@@ -36,6 +36,8 @@
 "find_next" = "Găsește următorul";
 "find_previous" = "Găsește anteriorul";
 "find_useSelection" = "Găsește selecția";
+"map_goToUserLocation" = "Accesează localizarea actuală";
+"map_resetHeading" = "Aliniază la nord";
 "navigation_back" = "Înapoi";
 "refresh" = "Reîmprospătare"; // More common in Apple strings files: Actualizeazăs
 "scrollView_zoomIn" = "Zoom înainte";

--- a/KeyboardKit/Localised/ru.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/ru.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Найти далее";
 "find_previous" = "Найти ранее";
 "find_useSelection" = "Найти выбранное";
+"map_goToUserLocation" = "Перейти к текущей геопозиции";
+"map_resetHeading" = "Привязать к северу";
 "navigation_back" = "Назад";
 "refresh" = "Обновить";
 "scrollView_zoomIn" = "Увеличить";

--- a/KeyboardKit/Localised/sk.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/sk.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Nájsť ďalšie";
 "find_previous" = "Nájsť predošlé";
 "find_useSelection" = "Použiť výber pri hľadaní";
+"map_goToUserLocation" = "Prejsť na aktuálnu polohu";
+"map_resetHeading" = "Fixovať sever";
 "navigation_back" = "Naspäť"; // Matches navigation controller button text. More common in Apple strings files: Späť
 "refresh" = "Osviežiť";
 "scrollView_zoomIn" = "Zväčšiť"; // This is most common in Apple strings files and seems to have a more appropriate meaning than the alternative Priblížiť (from Apple’s WebBrowser glossary file).

--- a/KeyboardKit/Localised/sv.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/sv.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Sök nästa";
 "find_previous" = "Sök föregående";
 "find_useSelection" = "Använd markering för sökning";
+"map_goToUserLocation" = "Gå till nuvarande plats";
+"map_resetHeading" = "Vänd mot norr";
 "navigation_back" = "Tillbaka";
 "refresh" = "Uppdatera";
 "scrollView_zoomIn" = "Zooma in";

--- a/KeyboardKit/Localised/th.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/th.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "ค้นหาถัดไป";
 "find_previous" = "ค้นหาก่อนหน้า";
 "find_useSelection" = "ใช้การเลือกสำหรับค้นหา";
+"map_goToUserLocation" = "ไปยังตำแหน่งที่ตั้งปัจจุบัน";
+"map_resetHeading" = "ทิศเหนือตลอด";
 "navigation_back" = "ย้อนกลับ";
 "refresh" = "ดึงข้อมูลใหม่";
 "scrollView_zoomIn" = "ซูมเข้า";

--- a/KeyboardKit/Localised/tr.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/tr.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Sonrakini Bul";
 "find_previous" = "Öncekini Bul";
 "find_useSelection" = "Bul İçin Seçimi Kullan";
+"map_goToUserLocation" = "Şu Anki Konuma Git";
+"map_resetHeading" = "Kuzeye Hizala";
 "navigation_back" = "Geri";
 "refresh" = "Yenile";
 "scrollView_zoomIn" = "Büyüt";

--- a/KeyboardKit/Localised/uk.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/uk.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Знайти наступне";
 "find_previous" = "Знайти попереднє";
 "find_useSelection" = "Використати виділене для пошуку";
+"map_goToUserLocation" = "Перейти до поточного місця";
+"map_resetHeading" = "Орієнтувати на північ";
 "navigation_back" = "Назад";
 "refresh" = "Оновити";
 "scrollView_zoomIn" = "Наблизити";

--- a/KeyboardKit/Localised/vi.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/vi.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "Tìm mục tiếp theo";
 "find_previous" = "Tìm mục trước";
 "find_useSelection" = "Sử dụng lựa chọn để tìm";
+"map_goToUserLocation" = "Đi tới vị trí hiện tại";
+"map_resetHeading" = "Chuyển nhanh hướng Bắc";
 "navigation_back" = "Quay lại";
 "refresh" = "Làm mới";
 "scrollView_zoomIn" = "Phóng to";

--- a/KeyboardKit/Localised/zh-HK.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/zh-HK.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "尋找下一個";
 "find_previous" = "尋找上一個";
 "find_useSelection" = "使用所選範圍尋找";
+"map_goToUserLocation" = "前往現時的位置";
+"map_resetHeading" = "貼齊北方";
 "navigation_back" = "返回";
 "refresh" = "重新整理";
 "scrollView_zoomIn" = "放大";

--- a/KeyboardKit/Localised/zh-Hans.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/zh-Hans.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "查找下一个";
 "find_previous" = "查找上一个";
 "find_useSelection" = "查找所选内容";
+"map_goToUserLocation" = "前往当前位置";
+"map_resetHeading" = "固定往北";
 "navigation_back" = "返回";
 "refresh" = "刷新";
 "scrollView_zoomIn" = "放大";

--- a/KeyboardKit/Localised/zh-Hant.lproj/KeyboardKit.strings
+++ b/KeyboardKit/Localised/zh-Hant.lproj/KeyboardKit.strings
@@ -32,6 +32,8 @@
 "find_next" = "尋找下一個";
 "find_previous" = "尋找上一個";
 "find_useSelection" = "使用所選範圍尋找";
+"map_goToUserLocation" = "前往目前位置";
+"map_resetHeading" = "朝向北方";
 "navigation_back" = "返回";
 "refresh" = "重新整理";
 "scrollView_zoomIn" = "放大";

--- a/KeyboardKit/LocalisedStringKeys.swift
+++ b/KeyboardKit/LocalisedStringKeys.swift
@@ -33,6 +33,8 @@ enum LocalisedStringKey: String {
     case find_next
     case find_previous
     case find_useSelection
+    case map_goToUserLocation
+    case map_resetHeading
     case navigation_back
     case refresh
     case scrollView_zoomIn

--- a/KeyboardKitDemo/AppDelegate.swift
+++ b/KeyboardKitDemo/AppDelegate.swift
@@ -49,6 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             try builder.insertChildren([
                 KeyboardScrollView.refreshKeyCommand,
                 KeyboardNavigationController.backKeyCommand,
+                KeyboardMapView.resetHeadingKeyCommand,
             ], atEndOfTopLevelMenu: .view)
 
 #if !targetEnvironment(macCatalyst)

--- a/KeyboardKitDemo/AppDelegate.swift
+++ b/KeyboardKitDemo/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Remove the Bigger/Smaller commands since we want those inputs for Zoom In and Zoom Out and the menu builder
             // inconveniently disallows commands with the same inputs, even if they’re used in different contexts.
             // A downside of removing this is that for some reason this stops cmd - zooming out with MKMapView.
-            // You can still zoom out with - (no modifier) or opt down arrow so this will have to be enough.
+x            // You can still zoom out with - (no modifier) or opt down arrow so this will have to be enough.
             try builder.removeMenu(.textSize)
 
             try builder.insertChildren([KeyboardDatePicker.goToTodayKeyCommand], atEndOfTopLevelMenu: .view)

--- a/KeyboardKitDemo/AppDelegate.swift
+++ b/KeyboardKitDemo/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             // Remove the Bigger/Smaller commands since we want those inputs for Zoom In and Zoom Out and the menu builder
             // inconveniently disallows commands with the same inputs, even if they’re used in different contexts.
+            // A downside of removing this is that for some reason this stops cmd - zooming out with MKMapView.
+            // You can still zoom out with - (no modifier) or opt down arrow so this will have to be enough.
             try builder.removeMenu(.textSize)
 
             try builder.insertChildren([KeyboardDatePicker.goToTodayKeyCommand], atEndOfTopLevelMenu: .view)

--- a/KeyboardKitDemo/AppDelegate.swift
+++ b/KeyboardKitDemo/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 KeyboardScrollView.refreshKeyCommand,
                 KeyboardNavigationController.backKeyCommand,
                 KeyboardMapView.resetHeadingKeyCommand,
+                KeyboardMapView.goToUserLocationKeyCommand,
             ], atEndOfTopLevelMenu: .view)
 
 #if !targetEnvironment(macCatalyst)

--- a/KeyboardKitDemo/Info.plist
+++ b/KeyboardKitDemo/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Used to show your location in the map view demo and enable the key command to focus the map on the current location.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/KeyboardKitDemo/MapViewController.swift
+++ b/KeyboardKitDemo/MapViewController.swift
@@ -1,6 +1,7 @@
 // Douglas Hill, March 2020
 
 import KeyboardKit
+import CoreLocation
 
 class MapViewController: FirstResponderViewController {
     override init() {
@@ -8,6 +9,8 @@ class MapViewController: FirstResponderViewController {
         title = "Map"
         tabBarItem.image = UIImage(systemName: "map")
     }
+
+    private let locationManager = CLLocationManager()
 
     private lazy var mapView = KeyboardMapView()
 
@@ -20,5 +23,13 @@ class MapViewController: FirstResponderViewController {
 
         // Without this, we end up with a transparent navigation bar background with the map content underneath.
         navigationItem.scrollEdgeAppearance = navigationController!.navigationBar.standardAppearance
+
+        mapView.showsUserLocation = true
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        locationManager.requestWhenInUseAuthorization()
     }
 }

--- a/KeyboardKitDemo/MapViewController.swift
+++ b/KeyboardKitDemo/MapViewController.swift
@@ -1,0 +1,24 @@
+// Douglas Hill, March 2020
+
+import KeyboardKit
+
+class MapViewController: FirstResponderViewController {
+    override init() {
+        super.init()
+        title = "Map"
+        tabBarItem.image = UIImage(systemName: "map")
+    }
+
+    private lazy var mapView = KeyboardMapView()
+
+    override func loadView() {
+        view = mapView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Without this, we end up with a transparent navigation bar background with the map content underneath.
+        navigationItem.scrollEdgeAppearance = navigationController!.navigationBar.standardAppearance
+    }
+}

--- a/KeyboardKitDemo/SceneDelegate.swift
+++ b/KeyboardKitDemo/SceneDelegate.swift
@@ -19,6 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             PagingScrollViewController(),
             TextViewController(),
             DatePickerViewController(),
+            MapViewController(),
         ])
 
         rootViewController.title = "KeyboardKit"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ KeyboardKit is designed to integrate with the UIKit focus system when available,
 - [Keyboard navigation without the focus system](/Features.md#keyboard-navigation-without-the-focus-system) (navigate with arrow keys and tab key)
 - [Additional navigation commands](/Features.md#additional-navigation-commands) (dismiss modals, change tabs, go back)
 - [Collection view and table view commands](/Features.md#collection-view-and-table-view-commands) (reorder, delete, select all)
-- [Keyboard scrolling and zooming](/Features.md#scrolling-and-zooming) (including page up, page down, home, end)
+- [Keyboard scrolling and zooming](/Features.md#scrolling-and-zooming) (including page up, page down, home, end — and map views)
 - [Key equivalents for buttons](Features.md#key-equivalents-for-buttons) (SwiftUI buttons, UIKit bar button items)
 - [Advanced text navigation](Features.md#advanced-text-navigation) (find next/previous, define)
 - [Keyboard window management](Features.md#window-management) (open, close, cycle)


### PR DESCRIPTION
This add a subclass of `MKMapView` that can be controlled using a keyboard. Most of this functionality is built into `MKMapView`, it‘s just not enabled because the view wouldn’t normally get keyboard focus.